### PR TITLE
Match filename extension only at the end of the filename

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -180,7 +180,7 @@ function getDownloadInfo(refs, version) {
     let versionMap = new Map();
     // Filter by platform
     refs.forEach(ref => {
-        if (ref.indexOf(extension) < 0) {
+        if (!ref.endsWith(extension + '">')) {
             return;
         }
         // If we haven't returned, means we're looking at the correct platform

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -192,7 +192,7 @@ function getDownloadInfo(
 
   // Filter by platform
   refs.forEach(ref => {
-    if (ref.indexOf(extension) < 0) {
+    if (!ref.endsWith(extension + '">')) {
       return;
     }
 


### PR DESCRIPTION
Changes the matching for filename extensions to only match extensions at the end of the filename, and ignore false matches with the same pattern in the middle of the name. This avoids wrongly matching .tar.gz.sig and zip.sig files in the CDN.

The change will prevent issues like #23 happening in the future if/as .sig files are added on the CDN. For the time being, the Zulu CDN has been cleansed of .sig files to avoid this issue, but we would like to be able to safely .sig files back up once this change makes it into a 1.x version of setup-java...

I have verified this change the entire range of Java versions (6, 7, 8, 9, 10, 11, 12, 13), update levels, and OS platforms available on the CDN at this point in time.